### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/log-request-response-with-body/src/main/java/com/frandorado/loggingrequestresponsewithbody/service/LoggingServiceImpl.java
+++ b/log-request-response-with-body/src/main/java/com/frandorado/loggingrequestresponsewithbody/service/LoggingServiceImpl.java
@@ -9,11 +9,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.java.Log;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import lombok.extern.log4j.Log4j2;
 
-@Component
+@Service
 @Log
 public class LoggingServiceImpl implements LoggingService {
     


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code. 

A Spring bean in the service layer should be annotated using @Service instead of @Component annotation.
@Service annotation is a specialization of @Component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @Service is a better choice.